### PR TITLE
trying to fix the background-size:cover in the teams page

### DIFF
--- a/src/containers/TeamsPage/TeamsPage.js
+++ b/src/containers/TeamsPage/TeamsPage.js
@@ -179,7 +179,7 @@ const styles = {
     position: "relative",
     top: 50,
     filter: "blur(.5px)",
-    backgroundSize: "cover",
+    backgroundSize: "cover !important",
     backgroundPositon: "100% 100%",
     borderRadius: 10,
     boxshadow: "1px 1px 25px 1px #999"


### PR DESCRIPTION
Noticed that the background-size: "cover" is not implemented in the teams page, trying to fix it...